### PR TITLE
Add new draft charter for the Working Group

### DIFF
--- a/wg-charter.html
+++ b/wg-charter.html
@@ -285,7 +285,7 @@
         <dt><a href="https://www.w3.org/wasm/">Web Assembly Working Group</a></dt>
         <dd>This Working Group develops a size- and load-time-efficient format and execution environment, allowing compilation to the web with consistent behavior across a variety of implementations.</dd>
 
-        <dt><a href="https://www.w3.org/groups/wg/webmachinelearning/">Web Machine Learning for the Web Working Group</a></dt>
+        <dt><a href="https://www.w3.org/groups/wg/webmachinelearning/">Web Machine Learning Working Group</a></dt>
         <dd>This Working Group develops a dedicated low-level Web API for enabling efficient machine learning inference in the browser.</dd>
           </dl>
           <h3 id="external-coordination">External Organizations</h3>

--- a/wg-charter.html
+++ b/wg-charter.html
@@ -220,9 +220,8 @@
           <dd>
               A Shading Language specification that defines the programmable
               interface to the GPU for the Web graphics and computation
-              pipeline, convertable to Khronos' SPIR-V language and composed
-              of constructs defined as normative references to their SPIR-V
-              counterparts.
+              pipeline, and that can be translated or compiled into
+              platform-specific instructions.
               <p class="draft-status"><b>Draft State:</b> Working Draft</p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2022/WD-WGSL-20220831/">31 August 2022</a></p>
               <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/WD-WGSL-20210518/">WebGPU Shading Language 18 May 2021</a>;

--- a/wg-charter.html
+++ b/wg-charter.html
@@ -1,0 +1,465 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+
+    <title>GPU for the Web Working Group Charter</title>
+
+    <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/pubrules-style.css" />
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css" />
+    <style type="text/css">
+      ul#navbar {
+        font-size: small;
+      }
+
+
+      dt.spec {
+        font-weight: bold;
+      }
+
+      dt.spec new {
+        background: yellow;
+      }
+
+      ul.out-of-scope > li {
+        font-weight: bold;
+      }
+
+      ul.out-of-scope > li > ul > li{
+        font-weight: normal;
+      }
+
+      .issue {
+        background: cornsilk;
+        font-style: italic;
+      }
+
+      .todo {
+        color: red;
+      }
+
+      footer {
+        font-size: small;
+      }
+
+    </style>
+  </head>
+  <body>
+    <header id="header">
+      <aside>
+        <ul id="navbar">
+          <li><a href="#scope">Scope</a></li>
+          <li><a href="#deliverables">Deliverables</a></li>
+          <li><a href="#success-criteria">Success criteria</a></li>
+          <li><a href="#coordination">Coordination</a></li>
+          <li><a href="#participation">Participation</a></li>
+          <li><a href="#communication">Communication</a></li>
+          <li><a href="#decisions">Decision Policy</a></li>
+          <li><a href="#patentpolicy">Patent Policy</a></li>
+          <li><a href="#licensing">Licensing</a></li>
+          <li><a href="#about">About this Charter</a></li>
+        </ul>
+      </aside>
+      <p>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72" /></a>
+
+      </p>
+    </header>
+
+    <main>
+      <h1 id="title"><i class="todo">PROPOSED</i> GPU for the Web Working Group Charter</h1>
+
+      <p class="todo"><strong>Warning:</strong> This document has no official status. It is a draft charter for discussion within the GPU for the Web groups and the W3C Advisory Committee.</p>
+
+      <p class="mission">The <strong>mission</strong> of the <a
+      href="https://www.w3.org/2020/gpu/">GPU for the Web Working Group</a> is to
+      provide an interface between the Web Platform and modern 3D graphics and
+      computation capabilities present on native system platforms.</p>
+
+      <div class="noprint">
+        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/125519/join">Join the GPU for the Web Working Group</a>.</p>
+      </div>
+
+      <section id="details">
+        <table class="summary-table">
+          <tr id="Duration">
+            <th>
+              Start date
+            </th>
+            <td>
+              20 August 2020
+            </td>
+          </tr>
+          <tr id="Duration">
+            <th>
+              End date
+            </th>
+            <td>
+              31 August 2022
+            </td>
+          </tr>
+
+          <tr>
+            <th>
+              Chairs
+            </th>
+            <td>
+              Kelsey Gilbert (Mozilla)<br/>
+              Corentin Wallez (Google)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Team Contacts
+            </th>
+            <td>
+              <a href="mailto:fd@w3.org">François Daoust</a> (0.05 <abbr title="Full-Time Equivalent">FTE</abbr>)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Meeting Schedule
+            </th>
+            <td>
+              <strong>Teleconferences:</strong> weekly or bi-weekly calls, as necessary.
+              <br />
+              <strong>Face-to-face:</strong> 3 times per year as necessary,
+              including during W3C's annual Technical Plenary week.
+            </td>
+          </tr>
+        </table>
+      </section>
+
+
+
+      <section id="scope" class="scope">
+        <h2>Scope</h2>
+        <p>
+            In this document, the term <dfn>GPU</dfn> stands for Graphics
+            Processing Unit, typically a piece of hardware dedicated to
+            efficiently processing graphics and related features.
+        </p>
+
+        <p>
+            This Working Group will recommend a Web programming interface for
+            graphics and computation that:
+        </p>
+
+        <ol>
+            <li>enables rendering of modern graphics to both onscreen and offscreen drawing surfaces</li>
+            <li>enables computation tasks to be performed, and the results of such tasks to be retrieved</li>
+            <li>This group will also recommend a companion Shading Language that describes the graphics and computation tasks in a format
+            that can be translated or compiled into platform-specific instructions</li>
+        </ol>
+
+        <p>
+            The API will not be restricted to any particular platform technology. Instead, it will
+            be generic enough to be implemented on top of modern GPU system APIs, such as
+            Microsoft's Direct3D 12, Apple's Metal, and Khronos's Vulkan.
+        </p>
+
+        <p>
+            This Working Group will investigate and document threat mitigation
+            strategies for the API, notably to address fingerprinting issues
+            and to prevent unauthorized use of computational resources.
+        </p>
+
+        <p>
+            Note that the majority of the input to this Working Group will come
+            directly from the <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a>.
+            No major development will happen in the Working Group itself. Instead, the Community
+            Group will be driving the technical work.
+        </p>
+
+        <h2>Out of Scope</h2>
+        <p>
+            The scope of work is restricted to the development of a programming
+            interface between the Web Platform and modern 3D graphics and
+            computation capabilities present on native system platforms. The work
+            will not define hardware features or algorithms, and the interface it
+            defines is not intended to be directly exposed by a GPU driver.
+        </p>
+
+      </section>
+
+
+
+      <section id="deliverables">
+        <h2>
+          Deliverables
+        </h2>
+
+        <div id="normative">
+          <h3>
+            Normative Specifications
+          </h3>
+          <dl>
+          <dt>WebGPU API</dt>
+
+          <dd>
+              An API for performing operations, such as rendering and
+              computation, on a Graphics Processing Unit (GPU).
+              <p class="draft-status"><b>Draft state:</b> <a href="https://gpuweb.github.io/gpuweb/">Adopted from the GPU for the Web Community Group</a></p>
+              <p class="milestone"><b>Recommendation expected completion:</b> Q1 2022</p>
+          </dd>
+
+          <dt>WebGPU Shading Language</dt>
+
+          <dd>
+              A Shading Language specification that defines the programmable
+              interface to the GPU for the Web graphics and computation
+              pipeline, convertable to Khronos' SPIR-V language and composed
+              of constructs defined as normative references to their SPIR-V
+              counterparts.
+              <p class="draft-status"><b>Draft state:</b> <a href="https://gpuweb.github.io/gpuweb/wgsl.html">Adopted from the GPU for the Web Community Group</a></p>
+              <p class="milestone"><b>Recommendation expected completion:</b> Q1 2022</p>
+          </dd>
+          </dl>
+        </div>
+
+        <div id="wg-other-deliverables">
+            <h3>
+              Other Deliverables
+            </h3>
+            <p>
+              This Working Group will produce conformance test suites and
+              implementation reports for its normative deliverables.
+            </p>
+            <p>
+              Other non-normative documents may be created, including:
+            </p>
+            <ul>
+              <li>Reference implementations of the group's deliverables</li>
+              <li>Use case and requirement documents</li>
+              <li>Explainers, primers and best-practice documents</li>
+            </ul>
+        </div>
+      </section>
+
+
+      <section id="success-criteria">
+        <h2>Success Criteria</h2>
+        <p>In order to advance to  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations of each feature defined in the specification</a>.</p>
+        <p>Each specification should contain a section detailing any <a href='https://www.w3.org/TR/security-privacy-questionnaire/'>known security</a>, fingerprinting, and privacy implications, and suggested mitigation strategies for implementers, web authors, and end users. The group should not publish a specification if acceptable mitigation strategies cannot be found.</p>
+        <p>Each specification should contain a section describing known impacts on accessibility to users with disabilities, ways the specification features address them, and recommendations for minimizing accessibility problems in implementation.</p>
+        <p>Normative specification changes are generally expected to have a corresponding set of tests, either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the proposed update.</p>
+      </section>
+
+
+      <section id="coordination">
+        <h2>Coordination</h2>
+        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/Charter.html#horizontal-review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Working Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+
+        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+
+        <div>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+            <dt><a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a></dt>
+            <dd>The GPU for the Web Community Group developed the specifications adopted by this Working Group. It is expected that the Community Group will continue to drive the technical work on the specifications and incubate new features. This Working Group will work with the GPU for the Web Community Group on shaping the specifications for the Recommendation track.</dd>
+
+            <dt><a href="https://www.w3.org/immersive-web/">Immersive Web Working Group</a></dt>
+            <dd>The Immersive Web Working Group produces specifications to interact with Virtual Reality (VR) and Augmented Reality (AR) devices and sensors, and may add a 3D rendering layer based on the WebGPU API.</dd>
+        <dt><a href="https://www.w3.org/2019/webapps/">Web Applications Working Group</a></dt>
+        <dd>The Web Applications Working Group (WebApps WG) produces specifications that facilitate the development of client-side web applications.</dd>
+
+        <dt><a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a></dt>
+        <dd>This Working Group develops security and policy mechanisms to improve the security of Web Applications, and enable secure cross-site communication.</dd>
+
+        <dt><a href="https://www.w3.org/wasm/">Web Assembly Working Group</a></dt>
+        <dd>This Working Group develops a size- and load-time-efficient format and execution environment, allowing compilation to the web with consistent behavior across a variety of implementations.</dd>
+
+        <dt><a href="https://www.w3.org/community/webmachinelearning/">Machine Learning for the Web Community Group</a></dt>
+        <dd>This Community Group incubates a dedicated low-level Web API for machine learning inference.</dd>
+          </dl>
+          <h3 id="external-coordination">External Organizations</h3>
+          <dl>
+          <dt><a title="WHATWG" href="https://whatwg.org/" id="whatwg">Web Hypertext Application Technology Working Group (WHATWG)</a></dt>
+          <dd>The Web Hypertext Application Technology Working Group (WHATWG) is a community of people interested in evolving the web through standards and tests.</dd>
+          <dt><a title="Khronos" href="https://khronos.org/" id="khronos">Khronos</a></dt>
+          <dd>The Khronos Organization is a standards body that develops many graphics-related technologies, including OpenGL, Vulkan and SPIR-V.</dd>
+          </dl>
+        </div>
+      </section>
+
+
+
+      <section class="participation">
+        <h2 id="participation">
+          Participation
+        </h2>
+        <p>
+          To be successful, this Working Group is expected to have 5 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a day per week towards the Working Group. There is no minimum requirement for other Participants.
+        </p>
+        <p>
+          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
+        </p>
+        <p>
+          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+        </p>
+        <p>
+          Participants in the group are required
+          (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>)
+          to follow the W3C
+          <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.
+        </p>
+        <p>
+          As stated above, the majority of the technical work for this Working Group will take place in the <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a>.
+        </p>
+      </section>
+
+
+
+      <section id="communication">
+        <h2>
+          Communication
+        </h2>
+        <p id="public">
+          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>. Meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository, and may permit direct public contribution requests.
+        </p>
+        <p>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/2020/gpu/">GPU for the Web Working Group home page.</a>
+        </p>
+        <p>
+          Most GPU for the Web Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+        </p>
+        <p>
+          This group primarily conducts its technical work in its <a href="https://github.com/gpuweb">public repositories</a>. There is also a public mailing list <a id="public-name" href="mailto:public-gpu@w3.org">public-gpu@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-gpu/">archive</a>).  The public is invited to contribute to the github repositories and post messages to the list. Regular activity summaries around the github repositories will be provided.
+        </p>
+      </section>
+
+
+
+      <section id="decisions">
+        <h2>
+          Decision Policy
+        </h2>
+        <p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+        <p>
+           However, if a decision is necessary for timely progress, but consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote, and record a decision along with any objections.
+        </p>
+        <p>
+          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional until 10 working days after the publication of the resolution in draft minutes sent, which will be published within 5 working days of the meeting to the working group's mailing list with a 'call for consensus' in the subject line. If no objections are raised on the mailing list by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
+        </p>
+        <p>
+          All decisions made by the group should be considered resolved unless and until new information becomes available, or unless reopened at the discretion of the Chairs or the Director.
+        </p>
+        <p>
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/policies#Votes">W3C Process Document (Section 3.4, Votes)</a>, and includes no voting procedures beyond what the Process Document requires.
+        </p>
+      </section>
+
+
+
+      <section id="patentpolicy">
+        <h2>
+          Patent Policy
+        </h2>
+        <p>
+          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent
+            Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
+
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
+        </p>
+      </section>
+
+      <section id="licensing">
+        <h2>Licensing</h2>
+        <p>This Working Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+      </section>
+
+      <section id="about">
+        <h2>
+          About this Charter
+        </h2>
+        <p>
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/groups#GAGeneral">section 5.2</a> of the <a href="https://www.w3.org/Consortium/Process">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+        </p>
+
+        <section id="history">
+          <h3>
+            Charter History
+          </h3>
+
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
+
+          <table class="history">
+            <tbody>
+              <tr>
+                <th>
+                  Charter Period
+                </th>
+                <th>
+                  Start Date
+                </th>
+                <th>
+                  End Date
+                </th>
+                <th>
+                  Changes
+                </th>
+              </tr>
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2020/08/gpuweb-charter.html">Initial Charter</a>
+                </th>
+                <td>
+                  20 August 2020
+                </td>
+                <td>
+                  31 August 2022
+                </td>
+                <td>
+                  Initial charter
+                </td>
+              </tr>
+              <tr>
+                <th><a href="#">Rechartered</a></th>
+                <td>15 December 2020</td>
+                <td>31 August 2022</td>
+                <td>New Patent Policy</td>
+              </tr>
+              <tr>
+                <th><a href="#">New co-chair</a></th>
+                <td>07 April 2021</td>
+                <td>31 August 2022</td>
+                <td>Jeff Gilbert replaces Dean Jackson as co-chair</td>
+              </tr>
+              <tr>
+                <th><a href="#">Co-chair update</a></th>
+                <td>17 February 2022</td>
+                <td>31 August 2022</td>
+                <td>Reflect change of firstname for Kelsey Gilbert</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </section>
+    </main>
+
+    <hr />
+
+    <footer>
+      <address>
+        <a href="mailto:fd@w3.org">François Daoust</a>
+      </address>
+
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
+        2020
+        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (
+        <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="https://www.keio.ac.jp/">Keio</a>,
+        <a href="https://ev.buaa.edu.cn/">Beihang</a>
+        ), All Rights Reserved.
+
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+      </p>
+    </footer>
+
+  </body>
+</html>

--- a/wg-charter.html
+++ b/wg-charter.html
@@ -9,10 +9,14 @@
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/pubrules-style.css" />
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css" />
     <style type="text/css">
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
       ul#navbar {
         font-size: small;
       }
-
 
       dt.spec {
         font-weight: bold;
@@ -36,13 +40,12 @@
       }
 
       .todo {
-        color: red;
+        color: #900;
       }
 
       footer {
         font-size: small;
       }
-
     </style>
   </head>
   <body>
@@ -88,7 +91,7 @@
               Start date
             </th>
             <td>
-              20 August 2020
+              <i class="todo">when approved</i>
             </td>
           </tr>
           <tr id="Duration">
@@ -96,7 +99,7 @@
               End date
             </th>
             <td>
-              31 August 2022
+              30 November 2024
             </td>
           </tr>
 
@@ -190,21 +193,29 @@
           Deliverables
         </h2>
 
+        <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/gpu/publications">group publication status page</a>.</p>
+
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
+
         <div id="normative">
           <h3>
             Normative Specifications
           </h3>
           <dl>
-          <dt>WebGPU API</dt>
+          <dt><a href="https://www.w3.org/TR/webgpu/">WebGPU API</a></dt>
 
           <dd>
               An API for performing operations, such as rendering and
               computation, on a Graphics Processing Unit (GPU).
-              <p class="draft-status"><b>Draft state:</b> <a href="https://gpuweb.github.io/gpuweb/">Adopted from the GPU for the Web Community Group</a></p>
-              <p class="milestone"><b>Recommendation expected completion:</b> Q1 2022</p>
+              <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+              <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2022/WD-webgpu-20220831/">31 August 2022</a></p>
+              <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webgpu-20210518/">WebGPU 18 May 2021</a>;
+                <br/>associated <a href="https://www.w3.org/mid/cfe-8036-f5ffade17337af94e77d0c1e588bbe63549638fb@w3.org">Call for Exclusion</a> on 2021-05-18 ended on 2021-10-15;
+                <br/>produced under Working Group charter: <a href="https://www.w3.org/2020/12/gpu-wg-charter.html">https://www.w3.org/2020/12/gpu-wg-charter.html</a></p>
+              <p class="milestone"><b>Expected completion:</b> Q4 2024</p>
           </dd>
 
-          <dt>WebGPU Shading Language</dt>
+          <dt><a href="https://www.w3.org/TR/WGSL/">WebGPU Shading Language</a></dt>
 
           <dd>
               A Shading Language specification that defines the programmable
@@ -212,8 +223,12 @@
               pipeline, convertable to Khronos' SPIR-V language and composed
               of constructs defined as normative references to their SPIR-V
               counterparts.
-              <p class="draft-status"><b>Draft state:</b> <a href="https://gpuweb.github.io/gpuweb/wgsl.html">Adopted from the GPU for the Web Community Group</a></p>
-              <p class="milestone"><b>Recommendation expected completion:</b> Q1 2022</p>
+              <p class="draft-status"><b>Draft State:</b> Working Draft</p>
+              <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2022/WD-WGSL-20220831/">31 August 2022</a></p>
+              <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/WD-WGSL-20210518/">WebGPU Shading Language 18 May 2021</a>;
+                <br/>associated <a href="https://www.w3.org/mid/cfe-8037-cd38c7697f2aa348acbe6b21de22a4ba3f55d0ea@w3.org">Call for Exclusion</a> on 2021-05-18 ended on 2021-10-15;
+                <br/>produced under Working Group charter: <a href="https://www.w3.org/2020/12/gpu-wg-charter.html">https://www.w3.org/2020/12/gpu-wg-charter.html</a></p>
+              <p class="milestone"><b>Expected completion:</b> Q4 2024</p>
           </dd>
           </dl>
         </div>
@@ -240,16 +255,16 @@
 
       <section id="success-criteria">
         <h2>Success Criteria</h2>
-        <p>In order to advance to  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations of each feature defined in the specification</a>.</p>
-        <p>Each specification should contain a section detailing any <a href='https://www.w3.org/TR/security-privacy-questionnaire/'>known security</a>, fingerprinting, and privacy implications, and suggested mitigation strategies for implementers, web authors, and end users. The group should not publish a specification if acceptable mitigation strategies cannot be found.</p>
-        <p>Each specification should contain a section describing known impacts on accessibility to users with disabilities, ways the specification features address them, and recommendations for minimizing accessibility problems in implementation.</p>
+        <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of each feature defined in the specification.</p>
+        <p>Each specification should contain sections detailing all known security and privacy &mdash;including fingerprinting&mdash; implications, and suggested mitigation strategies for implementers, web authors, and end users. The group should not publish a specification if acceptable mitigation strategies cannot be found.</p>
+        <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximising accessibility in implementations.</p>
         <p>Normative specification changes are generally expected to have a corresponding set of tests, either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the proposed update.</p>
       </section>
 
 
       <section id="coordination">
         <h2>Coordination</h2>
-        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/Charter.html#horizontal-review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Working Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Working Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
 
         <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 
@@ -270,8 +285,8 @@
         <dt><a href="https://www.w3.org/wasm/">Web Assembly Working Group</a></dt>
         <dd>This Working Group develops a size- and load-time-efficient format and execution environment, allowing compilation to the web with consistent behavior across a variety of implementations.</dd>
 
-        <dt><a href="https://www.w3.org/community/webmachinelearning/">Machine Learning for the Web Community Group</a></dt>
-        <dd>This Community Group incubates a dedicated low-level Web API for machine learning inference.</dd>
+        <dt><a href="https://www.w3.org/groups/wg/webmachinelearning/">Web Machine Learning for the Web Working Group</a></dt>
+        <dd>This Working Group develops a dedicated low-level Web API for enabling efficient machine learning inference in the browser.</dd>
           </dl>
           <h3 id="external-coordination">External Organizations</h3>
           <dl>
@@ -290,7 +305,7 @@
           Participation
         </h2>
         <p>
-          To be successful, this Working Group is expected to have 5 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a day per week towards the Working Group. There is no minimum requirement for other Participants.
+          To be successful, this Working Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other Participants.
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
@@ -316,7 +331,7 @@
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>. Meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository, and may permit direct public contribution requests.
+          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on public repositories and may permit direct public contribution requests. The meetings themselves are not open to public participation, however.
         </p>
         <p>
           Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/2020/gpu/">GPU for the Web Working Group home page.</a>
@@ -327,6 +342,9 @@
         <p>
           This group primarily conducts its technical work in its <a href="https://github.com/gpuweb">public repositories</a>. There is also a public mailing list <a id="public-name" href="mailto:public-gpu@w3.org">public-gpu@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-gpu/">archive</a>).  The public is invited to contribute to the github repositories and post messages to the list. Regular activity summaries around the github repositories will be provided.
         </p>
+        <p>
+          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+        </p>
       </section>
 
 
@@ -336,15 +354,19 @@
           Decision Policy
         </h2>
         <p>
-          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
         <p>
-           However, if a decision is necessary for timely progress, but consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote, and record a decision along with any objections.
+           However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
         </p>
         <p>
-          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional until 10 working days after the publication of the resolution in draft minutes sent, which will be published within 5 working days of the meeting to the working group's mailing list with a 'call for consensus' in the subject line. If no objections are raised on the mailing list by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
+          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id='cfc'>10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
+
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
         </p>
         <p>
-          All decisions made by the group should be considered resolved unless and until new information becomes available, or unless reopened at the discretion of the Chairs or the Director.
+          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
         </p>
         <p>
           This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/policies#Votes">W3C Process Document (Section 3.4, Votes)</a>, and includes no voting procedures beyond what the Process Document requires.
@@ -361,7 +383,7 @@
           This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent
             Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
 
-          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/gpu/ipr">licensing information</a>.
         </p>
       </section>
 
@@ -375,7 +397,7 @@
           About this Charter
         </h2>
         <p>
-          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/groups#GAGeneral">section 5.2</a> of the <a href="https://www.w3.org/Consortium/Process">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
         </p>
 
         <section id="history">
@@ -416,22 +438,32 @@
                 </td>
               </tr>
               <tr>
-                <th><a href="#">Rechartered</a></th>
+                <th><a href="https://www.w3.org/2020/12/gpu-wg-charter.html">Rechartered</a></th>
                 <td>15 December 2020</td>
                 <td>31 August 2022</td>
                 <td>New Patent Policy</td>
               </tr>
               <tr>
-                <th><a href="#">New co-chair</a></th>
+                <th><a href="https://www.w3.org/2020/12/gpu-wg-charter.html">New co-chair</a></th>
                 <td>07 April 2021</td>
                 <td>31 August 2022</td>
                 <td>Jeff Gilbert replaces Dean Jackson as co-chair</td>
               </tr>
               <tr>
-                <th><a href="#">Co-chair update</a></th>
+                <th><a href="https://www.w3.org/2020/12/gpu-wg-charter.html">Co-chair update</a></th>
                 <td>17 February 2022</td>
                 <td>31 August 2022</td>
                 <td>Reflect change of firstname for Kelsey Gilbert</td>
+              </tr>
+              <tr>
+                <th><a href="#">Rechartered</a></th>
+                <td><i class="todo">when approved</i></td>
+                <td>30 November 2024</td>
+                <td><ul>
+                  <li>Align text with charter template</li>
+                  <li>Refresh deliverables drafts info</li>
+                  <li>Replace Web Machine Learning Community Group with Working Group in coordination section</li>
+                </ul></td>
               </tr>
             </tbody>
           </table>
@@ -448,7 +480,7 @@
 
       <p class="copyright">
         <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2020
+        2022
         <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (
         <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,

--- a/wg-charter.html
+++ b/wg-charter.html
@@ -457,6 +457,12 @@
                 <td>Reflect change of firstname for Kelsey Gilbert</td>
               </tr>
               <tr>
+                <th><a href="https://www.w3.org/2020/12/gpu-wg-charter.html">Charter Extension</a></th>
+                <td>07 September 2022</td>
+                <td>30 November 2022</td>
+                <td>None</td>
+              </tr>
+              <tr>
                 <th><a href="#">Rechartered</a></th>
                 <td><i class="todo">when approved</i></td>
                 <td>30 November 2024</td>
@@ -464,6 +470,7 @@
                   <li>Align text with charter template</li>
                   <li>Refresh deliverables drafts info</li>
                   <li>Replace Web Machine Learning Community Group with Working Group in coordination section</li>
+                  <li>Add Unicode Technical Committee to coordination section</li>
                 </ul></td>
               </tr>
             </tbody>

--- a/wg-charter.html
+++ b/wg-charter.html
@@ -294,6 +294,8 @@
           <dd>The Web Hypertext Application Technology Working Group (WHATWG) is a community of people interested in evolving the web through standards and tests.</dd>
           <dt><a title="Khronos" href="https://khronos.org/" id="khronos">Khronos</a></dt>
           <dd>The Khronos Organization is a standards body that develops many graphics-related technologies, including OpenGL, Vulkan and SPIR-V.</dd>
+          <dt><a title="UTC" href="https://www.unicode.org/consortium/utc.html" id="utc">Unicode Technical Committee (UTC)</a></dt>
+          <dd>The Unicode Technical Committee is responsible for the development and maintenance of the Unicode Standard, including the Unicode Character Database. This Working Group will coordinate with the UTC where appropriate, notably with regards to supporting Unicode identifiers in the WebGPU Shading Language specification.</dd>
           </dl>
         </div>
       </section>


### PR DESCRIPTION
This adds a draft charter for the GPU for the Web Working Group for the period 2022-2024.

[First commit](https://github.com/gpuweb/admin/commit/297a735270764d835059257ee3d9e3e7227c35aa) adds a copy of the Working Group charter as it exists today, along with a note that this is a draft copy for discussion.

[Second commit](https://github.com/gpuweb/admin/commit/3ee4430d9999d5f90dbb8cbfcceca9f0aa0a7f2b) refreshes the contents of the draft charter (see commit description for details)

No other change made at this point. Feedback welcome!

[HTML preview available here](https://raw.githack.com/tidoust/admin-1/wg-charter-2022/wg-charter.html)