### PR TITLE
Clarify WGSL translatability

### DIFF
--- a/wg-charter.html
+++ b/wg-charter.html
@@ -220,8 +220,8 @@
           <dd>
               A Shading Language specification that defines the programmable
               interface to the GPU for the Web graphics and computation
-              pipeline, and that can be translated or compiled into
-              platform-specific instructions.
+              pipeline, and that can be translated into the shading languages
+              of the system APIs WebGPU is implemented upon.
               <p class="draft-status"><b>Draft State:</b> Working Draft</p>
               <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2022/WD-WGSL-20220831/">31 August 2022</a></p>
               <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/WD-WGSL-20210518/">WebGPU Shading Language 18 May 2021</a>;


### PR DESCRIPTION
Fixes #20

* Clarify that WGSL is intended to be translated into the shading languages of the system APIs and not directly to machine code