### PR TITLE
Drop text on CG to align with the WG operating mode

### DIFF
--- a/wg-charter.html
+++ b/wg-charter.html
@@ -176,13 +176,6 @@
             and to prevent unauthorized use of computational resources.
         </p>
 
-        <p>
-            Note that the majority of the input to this Working Group will come
-            directly from the <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a>.
-            No major development will happen in the Working Group itself. Instead, the Community
-            Group will be driving the technical work.
-        </p>
-
         <h2>Out of Scope</h2>
         <p>
             The scope of work is restricted to the development of a programming
@@ -280,7 +273,7 @@
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
             <dt><a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a></dt>
-            <dd>The GPU for the Web Community Group developed the specifications adopted by this Working Group. It is expected that the Community Group will continue to drive the technical work on the specifications and incubate new features. This Working Group will work with the GPU for the Web Community Group on shaping the specifications for the Recommendation track.</dd>
+            <dd>The GPU for the Web Community Group developed the specifications adopted by this Working Group. It is expected that the Community Group will continue to work on test suites, tools, white papers and other non normative reports associated with the deliverables of this Working Group.</dd>
 
             <dt><a href="https://www.w3.org/immersive-web/">Immersive Web Working Group</a></dt>
             <dd>The Immersive Web Working Group produces specifications to interact with Virtual Reality (VR) and Augmented Reality (AR) devices and sensors, and may add a 3D rendering layer based on the WebGPU API.</dd>
@@ -328,9 +321,6 @@
           (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>)
           to follow the W3C
           <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.
-        </p>
-        <p>
-          As stated above, the majority of the technical work for this Working Group will take place in the <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a>.
         </p>
       </section>
 
@@ -489,6 +479,7 @@
                   <li>Align text with charter template, refresh links</li>
                   <li>Add link to Conformance Test Suite</li>
                   <li>Switch to CR with Snapshots (no intent to advance to Recommendation) mode</li>
+                  <li>Clarify that technical discussions on the deliverables are now driven by this Working Group</li>
                 </ul></td>
               </tr>
             </tbody>


### PR DESCRIPTION
This update clarifies the relationship between the GPU for the Web Working Group and Community Group, dropping previous charter text as technical work now takes place in the context of the Working Group. The Coordination section notes the expectation that the Community Group may continue work on other parts such as the test suite, code examples and tools, etc.

This follows from email exchanges with chairs and @dontcallmedom and @ianbjacobs who run the W3C Community Group program at W3C, and discussions during last week's face-to-face meeting.

