### PR TITLE
start/end date cfp + 2y

### DIFF
--- a/wg-charter.html
+++ b/wg-charter.html
@@ -99,7 +99,7 @@
               Start date
             </th>
             <td>
-              <i class="todo">when approved</i>
+              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
             </td>
           </tr>
           <tr id="Duration">
@@ -107,7 +107,7 @@
               End date
             </th>
             <td>
-              30 November 2024
+              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
             </td>
           </tr>
 


### PR DESCRIPTION
Start date and end date boilerplate like other recent proposed charters (e.g. https://www.w3.org/2024/07/audio-wg-2024-ac.html) for approval+CFP and 2y to help resolve comment by @himorin in https://github.com/w3c/strategy/issues/480#issuecomment-2461353578